### PR TITLE
Fix: Corrected enable check variable in Lidarr-MusicAutomator

### DIFF
--- a/Lidarr-MusicAutomator.bash
+++ b/Lidarr-MusicAutomator.bash
@@ -16,8 +16,8 @@ settings () {
 
 verifyConfig () {
 
-	if [ "$lidarrMusicVideoAutomator" != "true" ]; then
-		log "Script is not enabled, enable by setting lidarrMusicVideoAutomator to \"true\" by modifying the \"/config/<filename>.conf\" config file..."
+	if [ "$enableLidarrMusicAutomator" != "true" ]; then
+		log "Script is not enabled, enable by setting enableLidarrMusicAutomator to \"true\" by modifying the \"/config/<filename>.conf\" config file..."
 		log "Sleeping (infinity)"
 		sleep infinity
 	fi


### PR DESCRIPTION
Fixed a bug in Lidarr-MusicAutomator.bash where it was checking the MusicVideo variable instead of its own enable variable.