### PR TITLE
Fix: Corrected enable check variable in Lidarr-MusicVideoAutomator

### DIFF
--- a/Lidarr-MusicVideoAutomator.bash
+++ b/Lidarr-MusicVideoAutomator.bash
@@ -44,8 +44,8 @@ ConfigureTidalDl () {
 
 verifyConfig () {
 
-	if [ "$enableLidarrMusicAutomator" != "true" ]; then
-		log "Script is not enabled, enable by setting enableLidarrMusicAutomator to \"true\" by modifying the \"/config/<filename>.conf\" config file..."
+	if [ "$lidarrMusicVideoAutomator" != "true" ]; then
+		log "Script is not enabled, enable by setting lidarrMusicVideoAutomator to \"true\" by modifying the \"/config/<filename>.conf\" config file..."
 		log "Sleeping (infinity)"
 		sleep infinity
 	fi


### PR DESCRIPTION
Fixed a bug in Lidarr-MusicVideoAutomator.bash where it was checking the LidarrMusic variable instead of its own enable variable.