### PR TITLE
Fix: Exclude TBA episodes from queue cleanup

### DIFF
--- a/Queue-Cleaner.bash
+++ b/Queue-Cleaner.bash
@@ -82,8 +82,9 @@ QueueCleanerProcess () {
   fi
 
   arrQueueIdCount=$(echo "$arrQueueData" | jq -r ".id" | wc -l)
-  arrQueueCompletedIds=$(echo "$arrQueueData" | jq -r 'select(.status=="completed") | select(.trackedDownloadStatus=="warning") | .id')
-  arrQueueIdsCompletedCount=$(echo "$arrQueueData" | jq -r 'select(.status=="completed") | select(.trackedDownloadStatus=="warning") | .id' | wc -l)
+  # Exclude TBA items from the "Completed/Warning" cleanup list
+  arrQueueCompletedIds=$(echo "$arrQueueData" | jq -r 'select(.status=="completed") | select(.trackedDownloadStatus=="warning") | select(.statusMessages | tostring | contains("TBA") | not) | .id')
+  arrQueueIdsCompletedCount=$(echo "$arrQueueCompletedIds" | wc -w)
   arrQueueFailedIds=$(echo "$arrQueueData" | jq -r 'select(.status=="failed") | .id')
   arrQueueIdsFailedCount=$(echo "$arrQueueData" | jq -r 'select(.status=="failed") | .id' | wc -l)
   arrQueueStalledIds=$(echo "$arrQueueData" | jq -r 'select(.status=="stalled") | .id')


### PR DESCRIPTION
I've been using the Queue Cleaner script and noticed it deletes downloaded episodes that are in a "Warning" state due to being "TBA" (To Be Announced).
  
The Problem:
 
When a new episode airs, Sonarr sometimes flags it with Episode has a TBA title and recently aired. This puts the item in a "Completed" but "Warning" state in the queue. The current script logic (select(.status=="completed") | select(.trackedDownloadStatus=="warning")) indiscriminately deletes these items, causing me to lose valid downloads that just needed a few hours for metadata to update.
  
Proposed Solution:
 
I've modified the jq filter to explicitly exclude items where the statusMessages contain "TBA". This allows the script to still clean up actual errors (like "Sample" or "No files found") while preserving these temporary metadata waits.

Code Change:
```
   # Old
   arrQueueCompletedIds=$(echo "$arrQueueData" | jq -r
     'select(.status=="completed") |
     select(.trackedDownloadStatus=="warning") | .id')
   
   # New
   arrQueueCompletedIds=$(echo "$arrQueueData" | jq -r
     'select(.status=="completed") |
     select(.trackedDownloadStatus=="warning") | select(.statusMessages |
     tostring | contains("TBA") | not) | .id')
```
I believe this would be a safer default for most users.