### PR TITLE
Fix: improve latest season selection by excluding specials and dummy seasons

### DIFF
--- a/Sonarr-DailySeriesEpisodeTrimmer.bash
+++ b/Sonarr-DailySeriesEpisodeTrimmer.bash
@@ -87,7 +87,7 @@ DailySeriesTrimmerProcess () {
 
         # If non-daily series, set maximum episode count to match latest season total episode count
         if [ $seriesType != "daily" ]; then
-            maximumDailyEpisodes=$(echo "$seriesData" | jq -r ".seasons | sort_by(.seasonNumber) | reverse | .[].statistics.totalEpisodeCount" | head -n1)
+            maximumDailyEpisodes=$(echo "$seriesData" | jq -r ".seasons | map(select(.seasonNumber > 0 and .statistics.totalEpisodeCount > 1)) | sort_by(.seasonNumber) | reverse | .[].statistics.totalEpisodeCount" | head -n1)
         fi
 
         # Skip processing if less than the maximumDailyEpisodes setting were found to be downloaded


### PR DESCRIPTION
The current logic for calculating the episode keep limit on standard series can be misled by Season 0 (Specials) or future "dummy"
  seasons (placeholder seasons with 0-1 episodes often found in Sonarr metadata). This results in the script setting an incorrectly
  low keep limit and deleting valid episodes from the actual latest aired season.

  This change refines the selection logic to:
   1. Explicitly ignore Season 0.
   2. Filter out placeholder seasons that contain 1 or fewer episodes.
   3. Ensure the episode count is pulled from the most recent season that actually contains aired content.