### PR TITLE
Fix root-owned file/directory creation on host mounts

### DIFF
--- a/Huntarr.bash
+++ b/Huntarr.bash
@@ -24,6 +24,7 @@ logfileSetup () {
 
   if [ ! -d "$dockerLogPath" ]; then
     mkdir -p "$dockerLogPath"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath"
     chmod 777 "$dockerLogPath"
   fi
 
@@ -36,6 +37,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerLogPath/$logFileName" ]; then
     echo "" > "$dockerLogPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath/$logFileName"
     chmod 666 "$dockerLogPath/$logFileName"
   fi
 }
@@ -79,10 +81,12 @@ HuntarrAPILimitFile () {
     # Create base directory for various functions/process
     if [ ! -d "/config/huntarr" ]; then
         mkdir -p "/config/huntarr" 
+        chown ${PUID:-1000}:${PGID:-1000} "/config/huntarr"
     fi
     apiLimitFile="Huntarr-api-search-count-$(date +"%Y_%m_%d").txt"
     if [ ! -f "/config/huntarr/$apiLimitFile" ]; then
         echo -n "0" > "/config/huntarr/$apiLimitFile"
+        chown ${PUID:-1000}:${PGID:-1000} "/config/huntarr/$apiLimitFile"
     fi
 
     if find "/config/huntarr" -type f -iname "Huntarr-api-search-count-*.txt" | read; then
@@ -199,11 +203,13 @@ HuntarrProcess () {
         # create log folder for searched items
         if [ ! -d "/config/huntarr/$settingsFileName/$arrApp" ]; then
             mkdir -p "/config/huntarr/$settingsFileName/$arrApp"
+            chown ${PUID:-1000}:${PGID:-1000} "/config/huntarr/$settingsFileName/$arrApp"
         fi
 
         # create log of searched item
         if [ ! -f "/config/huntarr/$settingsFileName/$arrApp/$arrItemId" ]; then
             touch "/config/huntarr/$settingsFileName/$arrApp/$arrItemId"
+            chown ${PUID:-1000}:${PGID:-1000} "/config/huntarr/$settingsFileName/$arrApp/$arrItemId"
         fi        
     done
 }

--- a/Lidarr-MusicAutomator.bash
+++ b/Lidarr-MusicAutomator.bash
@@ -53,6 +53,7 @@ ArlSetup () {
     if [ ! -d "$deemixFolder" ]; then
         log "Creating Deemix Config folder"
         mkdir -p "$deemixFolder"
+        chown ${PUID:-1000}:${PGID:-1000} "$deemixFolder"
     fi
     if [ -f "$deemixFolder/.arl" ]; then
         log "Deleting ARL"
@@ -87,6 +88,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerPath/$logFileName" ]; then
     echo "" > "$dockerPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerPath/$logFileName"
     chmod 666 "$dockerPath/$logFileName"
   fi
 }
@@ -191,6 +193,7 @@ SearchDeezerAlbums () {
                 # delete temporary download location if needed
                 if [ ! -d "$incompleteDownloadPath" ]; then
                     mkdir -p "$incompleteDownloadPath"
+                    chown ${PUID:-1000}:${PGID:-1000} "$incompleteDownloadPath"
                 fi
 
                 # download tracks
@@ -199,12 +202,14 @@ SearchDeezerAlbums () {
                 # Create import location
                 if [ ! -d "$completeDownloadPath" ]; then
                     mkdir -p "$completeDownloadPath"
+                    chown ${PUID:-1000}:${PGID:-1000} "$completeDownloadPath"
                     chmod 777 -R "$completeDownloadPath"
                 fi
 
                 # Create import location album folder
                 if [ ! -d "$completeDownloadPath/$downloadAlbumFolderName" ]; then
                     mkdir -p "$completeDownloadPath/$downloadAlbumFolderName"
+                    chown ${PUID:-1000}:${PGID:-1000} "$completeDownloadPath/$downloadAlbumFolderName"
                 fi
 
                 # Move downloaded files to import location album folder
@@ -222,6 +227,7 @@ SearchDeezerAlbums () {
 
             if [ ! -d "$completedSearchIdLocation" ]; then
                 mkdir -p "$completedSearchIdLocation"
+                chown ${PUID:-1000}:${PGID:-1000} "$completedSearchIdLocation"
                 chmod 777 -R "$completedSearchIdLocation"
             fi
 
@@ -321,6 +327,7 @@ LidarrWantedSearch () {
 
         if [ ! -d "$completedSearchIdLocation" ]; then
             mkdir -p "$completedSearchIdLocation"
+            chown ${PUID:-1000}:${PGID:-1000} "$completedSearchIdLocation"
             chmod 777 -R "$completedSearchIdLocation"
         fi
 

--- a/Lidarr-MusicVideoAutomator.bash
+++ b/Lidarr-MusicVideoAutomator.bash
@@ -71,6 +71,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerPath/logs/$logFileName" ]; then
     echo "" > "$dockerPath/logs/$logFileName"
+  chown ${PUID:-1000}:${PGID:-1000} "$dockerPath/logs/$logFileName"
     chmod 666 "$dockerPath/logs/$logFileName"
   fi
 }
@@ -205,12 +206,14 @@ CompletedFileMover () {
     if [ ! -d "$lidarrMusicVideoLibrary" ]; then
         log "$processCount/$lidarrArtistCount :: $lidarrArtistName :: $videoIdProcess/$videoIdsCount :: $videoArtist :: $videoYear :: $videoType :: $videoTitle :: Creating Library Folder"
         mkdir -p "$lidarrMusicVideoLibrary"
+        chown ${PUID:-1000}:${PGID:-1000} "$lidarrMusicVideoLibrary"
         chmod 777 "$lidarrMusicVideoLibrary"
     fi
 
     if [ ! -d "$lidarrMusicVideoLibrary/$lidarrArtistFolder" ]; then
         log "$processCount/$lidarrArtistCount :: $lidarrArtistName :: $videoIdProcess/$videoIdsCount :: $videoArtist :: $videoYear :: $videoType :: $videoTitle :: Creating Artist Folder: $lidarrArtistFolder"
         mkdir -p "$lidarrMusicVideoLibrary/$lidarrArtistFolder"
+        chown ${PUID:-1000}:${PGID:-1000} "$lidarrMusicVideoLibrary/$lidarrArtistFolder"
         chmod 777 "$lidarrMusicVideoLibrary/$lidarrArtistFolder"
     fi
 
@@ -454,6 +457,7 @@ tidalProcess () {
         if [ ! -d "$logFolder" ]; then
             log "$processCount/$lidarrArtistCount :: $lidarrArtistName :: $videoIdProcess/$videoIdsCount :: $videoArtist :: $videoYear :: $videoType :: $videoTitle :: Creating log folder: $logFolder"
             mkdir -p "$logFolder"
+            chown ${PUID:-1000}:${PGID:-1000} "$logFolder"
             chmod 777 "$logFolder"
         fi
 

--- a/Queue-Cleaner.bash
+++ b/Queue-Cleaner.bash
@@ -23,6 +23,7 @@ logfileSetup () {
 
   if [ ! -d "$dockerLogPath" ]; then
     mkdir -p "$dockerLogPath"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath"
     chmod 777 "$dockerLogPath"
   fi
 
@@ -35,6 +36,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerLogPath/$logFileName" ]; then
     echo "" > "$dockerLogPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath/$logFileName"
     chmod 666 "$dockerLogPath/$logFileName"
   fi
 }

--- a/Radarr-Invalid-Movie-Auto-Cleaner.bash
+++ b/Radarr-Invalid-Movie-Auto-Cleaner.bash
@@ -15,6 +15,7 @@ logfileSetup () {
 
   if [ ! -d "$dockerLogPath" ]; then
     mkdir -p "$dockerLogPath"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath"
     chmod 777 "$dockerLogPath"
   fi
 
@@ -27,6 +28,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerLogPath/$logFileName" ]; then
     echo "" > "$dockerLogPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath/$logFileName"
     chmod 666 "$dockerLogPath/$logFileName"
   fi
 }

--- a/Radarr-UnmappedFolderCleaner.bash
+++ b/Radarr-UnmappedFolderCleaner.bash
@@ -15,6 +15,7 @@ logfileSetup () {
 
   if [ ! -d "$dockerLogPath" ]; then
     mkdir -p "$dockerLogPath"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath"
     chmod 777 "$dockerLogPath"
   fi
 
@@ -27,6 +28,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerLogPath/$logFileName" ]; then
     echo "" > "$dockerLogPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath/$logFileName"
     chmod 666 "$dockerLogPath/$logFileName"
   fi
 }

--- a/Sonarr-DailySeriesEpisodeTrimmer.bash
+++ b/Sonarr-DailySeriesEpisodeTrimmer.bash
@@ -16,6 +16,7 @@ logfileSetup () {
 
   if [ ! -d "$dockerLogPath" ]; then
     mkdir -p "$dockerLogPath"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath"
     chmod 777 "$dockerLogPath"
   fi
 
@@ -28,6 +29,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerLogPath/$logFileName" ]; then
     echo "" > "$dockerLogPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath/$logFileName"
     chmod 666 "$dockerLogPath/$logFileName"
   fi
 }

--- a/Sonarr-Invalid-Series-Auto-Cleaner.bash
+++ b/Sonarr-Invalid-Series-Auto-Cleaner.bash
@@ -15,6 +15,7 @@ logfileSetup () {
 
   if [ ! -d "$dockerLogPath" ]; then
     mkdir -p "$dockerLogPath"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath"
     chmod 777 "$dockerLogPath"
   fi
 
@@ -27,6 +28,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerLogPath/$logFileName" ]; then
     echo "" > "$dockerLogPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath/$logFileName"
     chmod 666 "$dockerLogPath/$logFileName"
   fi
 }

--- a/Sonarr-UnmappedFolderCleaner.bash
+++ b/Sonarr-UnmappedFolderCleaner.bash
@@ -15,6 +15,7 @@ logfileSetup () {
 
   if [ ! -d "$dockerLogPath" ]; then
     mkdir -p "$dockerLogPath"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath"
     chmod 777 "$dockerLogPath"
   fi
 
@@ -27,6 +28,7 @@ logfileSetup () {
   
   if [ ! -f "$dockerLogPath/$logFileName" ]; then
     echo "" > "$dockerLogPath/$logFileName"
+    chown ${PUID:-1000}:${PGID:-1000} "$dockerLogPath/$logFileName"
     chmod 666 "$dockerLogPath/$logFileName"
   fi
 }


### PR DESCRIPTION
  ### Description
  This PR addresses an issue where scripts running inside the container create directories and files
  (logs, search records, and download folders) as the root user. In many setups, these paths are mapped
  to host volumes, leading to Permission Denied errors for the main Arr applications
  (Sonarr/Radarr/Lidarr) which typically run as a non-root user (UID 1000).


###   Changes
   - Added chown calls after every mkdir and touch command across all 9 scripts.
   - Updated logfileSetup to ensure log files created by the container are owned by the correct user.
   - Utilized ${PUID:-1000} and ${PGID:-1000} to respect Docker environment variables.


###   Note on Defaults
  I have used 1000:1000 as the fallback default as it is the standard for most Docker home-server
  environments (LinuxServer.io, hotio, etc.). I recognize that this default may not apply to every
  system (e.g., Synology or custom UID setups), but by utilizing the environment variables, users can
  easily override this in their docker-compose.yml or environment config without modifying the scripts.